### PR TITLE
feat: conversion from u64 to StateHash, closes #58

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -326,7 +326,7 @@ pub enum StateError {
     EntityError(#[from] EntityError),
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Display, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Display, Default, From, Into, AsRef, AsMut)]
 pub struct StateHash(u64);
 
 impl StateHash {


### PR DESCRIPTION
Derive the From, Into, AsRef, Asmut trait with derive_more

<!--
Update "[ ]" to "[x]" to check a box
-->
<!-- Derived from https://github.com/tauri-apps/tauri/blob/dev/.github/PULL_REQUEST_TEMPLATE.md -->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Performance
- [ ] Test
- [ ] CI
- [ ] Other, please describe:

### Description
<!-- Describe your changes in detail -->

Derives the `From`, `Into`, `AsRef` and `AsMut` trait with derive_more for state::StateHash.

### Reason for change
<!-- If this is a bug fix, provide the issue number. If this is a feature, explain why the change is necessary. If this is a documentation change, explain why it should be added. -->

Otherwise it is not possible to convert an existing hash to a StateHash.

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature
- [x] I have added necessary documentation
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

### Other information