### PR TITLE
feat!: modify_state option for full_traversal and iteration_limit for uniform_distribution_is_steady, closes #67

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -168,9 +168,13 @@ impl Simulation {
         self.cache.graph(self.possible_states.clone())
     }
 
-    pub fn uniform_distribution_is_steady(&self) -> Result<bool, ErrorKind> {
+
+    pub fn uniform_distribution_is_steady(
+        &mut self,
+        iteration_limit: Option<Time>,
+    ) -> Result<bool, ErrorKind> {
         let mut simulation = Simulation::new(self.initial_state.clone(), self.rules.clone());
-        simulation.full_traversal(None, false)?;
+        simulation.full_traversal(iteration_limit, false)?;
         let uniform_probability = Probability::from(1. / simulation.possible_states.len() as f64);
         let uniform_distribution: ReachableStates = ReachableStates::from(HashMap::from_iter(
             simulation.possible_states.iter().map(|(state_hash, _)| {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -168,7 +168,6 @@ impl Simulation {
         self.cache.graph(self.possible_states.clone())
     }
 
-
     pub fn uniform_distribution_is_steady(
         &mut self,
         iteration_limit: Option<Time>,

--- a/tests/random_walk.rs
+++ b/tests/random_walk.rs
@@ -87,6 +87,14 @@ fn random_walk() {
         simulation.next_step().unwrap();
     }
     println!("{}", &simulation);
+    assert_eq!(simulation.possible_states().clone(), {
+        let mut simulation_clone = setup();
+        simulation_clone
+            .full_traversal(Some(Time::from(100)), true)
+            .unwrap();
+        dbg!(&simulation_clone);
+        simulation_clone.possible_states().clone()
+    });
     assert_eq!(simulation.reachable_states().len(), MAX_AMOUNT as usize + 1);
     assert_eq!(simulation.entropy(), Entropy::from(2.3009662938553714));
     let expected_reachable_states = {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box
-->
<!-- Derived from https://github.com/tauri-apps/tauri/blob/dev/.github/PULL_REQUEST_TEMPLATE.md -->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Performance
- [ ] Test
- [ ] CI
- [ ] Other, please describe:

### Description
<!-- Describe your changes in detail -->

#### Add modify_state option to Simulation::full_traversal

modify_state determines whether to modify the reachable states,
time and entropy when calling full_traversal

BREAKING CHANGES: full_traversal needs the modify_state parameter

#### uniform_distribution_is_steady has an iteration_limit

uniform_distribution_limit takes the parameter iteration_limit which works
like the iteration_limit in full_traversal

BREAKING CHANGES: uniform_distribution_is_steady needs the iteration_limit parameter

### Reason for change
<!-- If this is a bug fix, provide the issue number. If this is a feature, explain why the change is necessary. If this is a documentation change, explain why it should be added. -->

This enables using the cache generated in uniform_distribution_is_steady for the simulation. Also it is now possible to stop the calculation after some iterations, as it could take possible infinite time.

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #67
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature
- [x] I have added necessary documentation
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

### Other information