### PR TITLE
feat: Implement Iterator for Simulation, closes #66

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -78,6 +78,18 @@ impl Display for Simulation {
     }
 }
 
+impl Iterator for Simulation {
+    type Item = Result<Simulation, ErrorKind>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = self.next_step();
+        match result {
+            Ok(_) => Some(Ok(self.clone())),
+            Err(error) => Some(Err(error)),
+        }
+    }
+}
+
 impl Simulation {
     pub fn new(initial_state: State, rules: HashMap<RuleName, Rule>) -> Simulation {
         let initial_state_hash = StateHash::new(&initial_state);

--- a/tests/random_walk.rs
+++ b/tests/random_walk.rs
@@ -86,14 +86,18 @@ fn random_walk() {
     for _ in 0..MAX_TIME {
         simulation.next_step().unwrap();
     }
-    println!("{}", &simulation);
     assert_eq!(simulation.possible_states().clone(), {
         let mut simulation_clone = setup();
         simulation_clone.full_traversal(Some(100), true).unwrap();
-        dbg!(&simulation_clone);
         simulation_clone.possible_states().clone()
     });
-    dbg!(&simulation.history());
+    assert_eq!(simulation.reachable_states().clone(), {
+        let mut simulation_clone = setup();
+        for _ in 0..MAX_TIME {
+            simulation_clone.next().unwrap().unwrap();
+        }
+        simulation_clone.reachable_states().clone()
+    });
     assert_eq!(simulation.reachable_states().len(), MAX_AMOUNT as usize + 1);
     assert_eq!(simulation.entropy(), Entropy::from(2.3009662938553714));
     let expected_reachable_states = {
@@ -131,7 +135,6 @@ fn random_walk() {
             ),
         )]))
         .unwrap();
-    println!("{}", simulation);
     assert_eq!(simulation.reachable_states().len(), 1);
     assert_eq!(simulation.entropy(), Entropy::from(0.));
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box
-->
<!-- Derived from https://github.com/tauri-apps/tauri/blob/dev/.github/PULL_REQUEST_TEMPLATE.md -->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Performance
- [ ] Test
- [ ] CI
- [ ] Other, please describe:

### Description
<!-- Describe your changes in detail -->

Implements the Iterator trait for Simulator. The `next()` method is equivalent to `Some(next_step())`.

### Reason for change
<!-- If this is a bug fix, provide the issue number. If this is a feature, explain why the change is necessary. If this is a documentation change, explain why it should be added. -->

This makes it a bit easier to iterate over the simulation.

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature
- [x] I have added necessary documentation
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

### Other information