### PR TITLE
feat!: euklidean norm, closes #30

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -117,6 +117,15 @@ impl Simulation {
         &self.history
     }
 
+    pub fn clone_without_history(&self) -> Simulation {
+        Simulation {
+            history: History::new(self.initial_distribution().clone()),
+            rules: self.rules.clone(),
+            possible_states: self.possible_states.clone(),
+            cache: self.cache.clone(),
+        }
+    }
+
     pub fn initial_distribution(&self) -> &ReachableStates {
         self.history.steps().first().unwrap().reachable_states()
     }

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    ops::{Div, Mul},
+};
 
 use backtrace::Backtrace as trc;
 use derive_more::*;
@@ -148,6 +151,22 @@ impl From<f64> for Probability {
     fn from(probability: f64) -> Self {
         debug_assert!((0. ..=1.).contains(&probability));
         Self(probability)
+    }
+}
+
+impl Mul<Probability> for Probability {
+    type Output = Probability;
+
+    fn mul(self, rhs: Probability) -> Self::Output {
+        Self(self.0 * rhs.0)
+    }
+}
+
+impl Div<Probability> for Probability {
+    type Output = Probability;
+
+    fn div(self, rhs: Probability) -> Self::Output {
+        Self(self.0 / rhs.0)
     }
 }
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -49,8 +49,8 @@ impl From<f64> for Amount {
 }
 
 impl Amount {
-    pub fn new() -> Self {
-        Self(0.)
+    pub fn new(amount: f64) -> Self {
+        Self(amount)
     }
 
     pub fn to_f64(&self) -> f64 {
@@ -102,8 +102,9 @@ impl From<f64> for Entropy {
 }
 
 impl Entropy {
-    pub fn new() -> Self {
-        Self(0.)
+    pub fn new(entropy: f64) -> Self {
+        debug_assert!(entropy >= 0.);
+        Self(entropy)
     }
 }
 
@@ -151,8 +152,9 @@ impl From<f64> for Probability {
 }
 
 impl Probability {
-    pub fn new() -> Self {
-        Self(0.)
+    pub fn new(probability: f64) -> Self {
+        debug_assert!((0. ..=1.).contains(&probability));
+        Self(probability)
     }
 
     pub fn from_probability_weight(probability_weight: ProbabilityWeight) -> Self {

--- a/tests/random_walk.rs
+++ b/tests/random_walk.rs
@@ -163,4 +163,13 @@ fn random_walk() {
             0.,
         ]
     );
+    assert_eq!(
+        simulation
+            .history()
+            .steps()
+            .iter()
+            .map(|step| step.reachable_states().len())
+            .collect::<Vec<usize>>(),
+        vec![1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 1]
+    );
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box
-->
<!-- Derived from https://github.com/tauri-apps/tauri/blob/dev/.github/PULL_REQUEST_TEMPLATE.md -->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Performance
- [x] Test
- [ ] CI
- [ ] Other, please describe:

### Description
<!-- Describe your changes in detail -->

#### new() constructors for units now take a value instead of using 0.

BREAKING CHANGE: new() constructors for units now take a value instead of using 0.

#### Add euclidean_norm to ReachableStates, closes #30

#### ReachableStates::probability

A simple method to get the probability of a specific state in ReachableStates

#### Simulation::clone_without_history

#### assert proper history in random_walk

### Reason for change
<!-- If this is a bug fix, provide the issue number. If this is a feature, explain why the change is necessary. If this is a documentation change, explain why it should be added. -->

#30

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature
- [ ] I have added necessary documentation
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

### Other information