### PR TITLE
feat: Serialization support, closes #38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ petgraph = "0.6.2"
 rayon = "1.5"
 serde = { version = "1.0.152", features = ["derive"]}
 thiserror = "1.0.38"
+serde_json = "1.0.91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ documentation = "https://docs.rs/entromatica"
 [dependencies]
 backtrace = "0.3.67"
 derive_more = "0.99.17"
-hashbrown = { version = "0.13.1", features = ["rayon"] }
+hashbrown = { version = "0.13.1", features = ["rayon", "serde"] }
 itertools = "0.10.5"
 petgraph = "0.6.2"
 rayon = "1.5"
+serde = { version = "1.0.152", features = ["derive"]}
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,6 @@ petgraph = "0.6.2"
 rayon = "1.5"
 serde = { version = "1.0.152", features = ["derive"]}
 thiserror = "1.0.38"
+
+[dev-dependencies]
 serde_json = "1.0.91"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -137,7 +137,7 @@ pub(self) enum RuleCacheError {
 #[error(transparent)]
 pub(crate) struct InternalCacheError(#[from] RuleCacheError);
 
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct Cache {
     rules: HashMap<RuleName, RuleCache>,
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,19 +1,16 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 
-#[allow(unused_imports)]
-use hashbrown::{HashMap, HashSet};
-#[allow(unused_imports)]
-use itertools::Itertools;
-
 use backtrace::Backtrace as trc;
+use hashbrown::HashMap;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::prelude::*;
 
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
 pub(self) struct RuleCache {
     condition: HashMap<StateHash, RuleApplies>,
     actions: HashMap<StateHash, StateHash>,
@@ -353,7 +350,7 @@ impl From<RuleCacheError> for CacheError {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct ConditionCacheUpdate {
     pub(self) rule_name: RuleName,
     pub(self) base_state_hash: StateHash,
@@ -381,7 +378,7 @@ impl ConditionCacheUpdate {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct ActionCacheUpdate {
     pub(self) rule_name: RuleName,
     pub(self) base_state_hash: StateHash,

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,13 +1,10 @@
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 
-#[allow(unused_imports)]
-use hashbrown::{HashMap, HashSet};
-#[allow(unused_imports)]
-use itertools::Itertools;
-
 use backtrace::Backtrace as trc;
 use derive_more::*;
+use hashbrown::HashMap;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::prelude::*;
@@ -52,6 +49,8 @@ pub enum Condition {
     MulAssign,
     DivAssign,
     RemAssign,
+    Serialize,
+    Deserialize,
 )]
 pub struct ProbabilityWeight(f64);
 
@@ -224,7 +223,21 @@ pub enum RuleError {
 }
 
 #[derive(
-    Copy, Clone, PartialEq, Eq, Hash, Debug, Display, Default, From, Into, AsRef, AsMut, Not,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Display,
+    Default,
+    From,
+    Into,
+    AsRef,
+    AsMut,
+    Not,
+    Serialize,
+    Deserialize,
 )]
 pub struct RuleApplies(bool);
 
@@ -242,7 +255,21 @@ impl RuleApplies {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, Default, From, AsRef, AsMut, Into)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Display,
+    Default,
+    From,
+    AsRef,
+    AsMut,
+    Into,
+    Serialize,
+    Deserialize,
+)]
 pub struct RuleName(String);
 
 impl RuleName {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
 
 use crate::prelude::*;
-use hashbrown::HashMap;
+
+use hashbrown::{HashMap, HashSet};
 use petgraph::Graph;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Step {
@@ -47,7 +49,49 @@ impl History {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct SerializableStep {
+    reachable_states: ReachableStates,
+    applied_rules: HashSet<RuleName>,
+}
+
+impl SerializableStep {
+    pub fn to_step(&self, rules: &HashMap<RuleName, Rule>) -> Result<Step, RuleError> {
+        Ok(Step {
+            reachable_states: self.reachable_states.clone(),
+            applied_rules: self
+                .applied_rules
+                .iter()
+                .map(|rule_name| {
+                    let rule = rules.get(rule_name);
+                    if let Some(rule) = rule {
+                        Ok((rule_name.clone(), rule.clone()))
+                    } else {
+                        Err(RuleError::RuleNotFound {
+                            rule_name: rule_name.clone(),
+                            context: get_backtrace(),
+                        })
+                    }
+                })
+                .collect::<Result<HashMap<RuleName, Rule>, RuleError>>()?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct SerializableHistory {
+    steps: Vec<SerializableStep>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct SerializableSimulation {
+    history: SerializableHistory,
+    rules: HashSet<RuleName>,
+    possible_states: PossibleStates,
+    cache: Cache,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Simulation {
     history: History,
     rules: HashMap<RuleName, Rule>,
@@ -114,6 +158,59 @@ impl Simulation {
 
     pub fn history(&self) -> &History {
         &self.history
+    }
+
+    pub fn to_serializable(&self) -> SerializableSimulation {
+        let history = SerializableHistory {
+            steps: self
+                .history
+                .steps()
+                .iter()
+                .map(|step| SerializableStep {
+                    reachable_states: step.reachable_states().clone(),
+                    applied_rules: step.applied_rules().keys().cloned().collect(),
+                })
+                .collect(),
+        };
+        SerializableSimulation {
+            history,
+            rules: self.rules.keys().cloned().collect(),
+            possible_states: self.possible_states.clone(),
+            cache: self.cache.clone(),
+        }
+    }
+
+    pub fn from_serializable(
+        serializable_simulation: SerializableSimulation,
+        rules: HashMap<RuleName, Rule>,
+    ) -> Result<Simulation, ErrorKind> {
+        let steps: Vec<Step> = serializable_simulation
+            .history
+            .steps
+            .iter()
+            .map(|step| step.to_step(&rules))
+            .collect::<Result<Vec<Step>, RuleError>>()?;
+        let history = History { steps };
+        Ok(Simulation {
+            history,
+            rules: serializable_simulation
+                .rules
+                .iter()
+                .map(|rule_name| {
+                    let rule = rules.get(rule_name);
+                    if let Some(rule) = rule {
+                        Ok((rule_name.clone(), rule.clone()))
+                    } else {
+                        Err(RuleError::RuleNotFound {
+                            rule_name: rule_name.clone(),
+                            context: get_backtrace(),
+                        })
+                    }
+                })
+                .collect::<Result<HashMap<RuleName, Rule>, RuleError>>()?,
+            possible_states: serializable_simulation.possible_states,
+            cache: serializable_simulation.cache,
+        })
     }
 
     pub fn clone_without_history(&self) -> Simulation {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,9 +1,8 @@
 use std::fmt::Display;
 
+use crate::prelude::*;
 use hashbrown::HashMap;
 use petgraph::Graph;
-
-use crate::prelude::*;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Step {

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,16 +4,30 @@ use std::hash::{Hash, Hasher};
 use std::sync::mpsc::SendError;
 use std::sync::Mutex;
 
-use hashbrown::HashMap;
-
 use backtrace::Backtrace as trc;
 use derive_more::*;
+use hashbrown::HashMap;
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::prelude::*;
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, Default, From, AsRef, AsMut, Into)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Display,
+    Default,
+    From,
+    AsRef,
+    AsMut,
+    Into,
+    Serialize,
+    Deserialize,
+)]
 pub struct ParameterName(String);
 
 impl ParameterName {
@@ -22,7 +36,7 @@ impl ParameterName {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Default)]
+#[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct Entity {
     parameters: HashMap<ParameterName, Amount>,
 }
@@ -84,7 +98,21 @@ pub enum EntityError {
     },
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, Default, From, Into, AsRef, AsMut)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Display,
+    Default,
+    From,
+    Into,
+    AsRef,
+    AsMut,
+    Serialize,
+    Deserialize,
+)]
 pub struct EntityName(pub String);
 
 impl EntityName {
@@ -93,7 +121,7 @@ impl EntityName {
     }
 }
 
-#[derive(Clone, Debug, Default, From, Into)]
+#[derive(Clone, Debug, Default, From, Into, Serialize, Deserialize)]
 pub struct State {
     entities: HashMap<EntityName, Entity>,
 }
@@ -320,7 +348,22 @@ pub enum StateError {
     EntityError(#[from] EntityError),
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Display, Default, From, Into, AsRef, AsMut)]
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Display,
+    Default,
+    From,
+    Into,
+    AsRef,
+    AsMut,
+    Serialize,
+    Deserialize,
+)]
 pub struct StateHash(u64);
 
 impl StateHash {
@@ -331,7 +374,9 @@ impl StateHash {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Default, From, Into, AsRef, AsMut, Index)]
+#[derive(
+    Clone, PartialEq, Eq, Debug, Default, From, Into, AsRef, AsMut, Index, Serialize, Deserialize,
+)]
 pub struct PossibleStates(HashMap<StateHash, State>);
 
 impl Display for PossibleStates {
@@ -425,7 +470,9 @@ pub enum PossibleStatesError {
     },
 }
 
-#[derive(Clone, PartialEq, Debug, Default, From, Into, AsRef, AsMut, Index)]
+#[derive(
+    Clone, PartialEq, Debug, Default, From, Into, AsRef, AsMut, Index, Serialize, Deserialize,
+)]
 pub struct ReachableStates(HashMap<StateHash, Probability>);
 
 impl Display for ReachableStates {

--- a/src/units.rs
+++ b/src/units.rs
@@ -5,6 +5,7 @@ use std::{
 
 use backtrace::Backtrace as trc;
 use derive_more::*;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::prelude::*;
@@ -30,6 +31,8 @@ use crate::prelude::*;
     MulAssign,
     DivAssign,
     RemAssign,
+    Serialize,
+    Deserialize,
 )]
 pub struct Amount(f64);
 
@@ -82,6 +85,8 @@ impl Amount {
     MulAssign,
     DivAssign,
     RemAssign,
+    Serialize,
+    Deserialize,
 )]
 pub struct Entropy(f64);
 
@@ -132,6 +137,8 @@ impl Entropy {
     MulAssign,
     DivAssign,
     RemAssign,
+    Serialize,
+    Deserialize,
 )]
 pub struct Probability(f64);
 

--- a/tests/random_walk.rs
+++ b/tests/random_walk.rs
@@ -173,3 +173,38 @@ fn random_walk() {
         vec![1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5, 1]
     );
 }
+
+#[test]
+fn serialization() {
+    let mut simulation = setup();
+    for _ in 0..MAX_TIME {
+        simulation.next_step().unwrap();
+    }
+    let serialized_reachable_states = serde_json::to_string(simulation.reachable_states()).unwrap();
+    assert_eq!(
+        serialized_reachable_states,
+        r#"{"10921680398206464020":0.248046875,"7911799719936081424":0.1611328125,"16318861240434570188":0.21484375,"3732191206693521782":0.1611328125,"8001857008351451444":0.21484375}"#
+    );
+
+    let serialized_possible_states = serde_json::to_string(simulation.possible_states()).unwrap();
+    assert_eq!(
+        serialized_possible_states,
+        r#"{"10921680398206464020":{"entities":{"main":{"parameters":{"point":0.0}}}},"7911799719936081424":{"entities":{"main":{"parameters":{"point":4.0}}}},"16318861240434570188":{"entities":{"main":{"parameters":{"point":2.0}}}},"3732191206693521782":{"entities":{"main":{"parameters":{"point":1.0}}}},"8001857008351451444":{"entities":{"main":{"parameters":{"point":3.0}}}}}"#
+    );
+    let serializable_simulation = simulation.to_serializable();
+    let simulation_string = serde_json::to_string(&serializable_simulation).unwrap();
+    assert_eq!(
+        simulation_string,
+        r#"{"history":{"steps":[{"reachable_states":{"10921680398206464020":1.0},"applied_rules":[]},{"reachable_states":{"7911799719936081424":0.5,"3732191206693521782":0.5},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.5,"16318861240434570188":0.25,"8001857008351451444":0.25},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"7911799719936081424":0.375,"16318861240434570188":0.125,"8001857008351451444":0.125,"3732191206693521782":0.375},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.375,"7911799719936081424":0.0625,"16318861240434570188":0.25,"3732191206693521782":0.0625,"8001857008351451444":0.25},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.0625,"7911799719936081424":0.3125,"16318861240434570188":0.15625,"3732191206693521782":0.3125,"8001857008351451444":0.15625},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.3125,"7911799719936081424":0.109375,"16318861240434570188":0.234375,"3732191206693521782":0.109375,"8001857008351451444":0.234375},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.109375,"7911799719936081424":0.2734375,"16318861240434570188":0.171875,"3732191206693521782":0.2734375,"8001857008351451444":0.171875},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.2734375,"7911799719936081424":0.140625,"16318861240434570188":0.22265625,"3732191206693521782":0.140625,"8001857008351451444":0.22265625},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.140625,"7911799719936081424":0.248046875,"16318861240434570188":0.181640625,"3732191206693521782":0.248046875,"8001857008351451444":0.181640625},"applied_rules":["walk forward","walk back"]},{"reachable_states":{"10921680398206464020":0.248046875,"7911799719936081424":0.1611328125,"16318861240434570188":0.21484375,"3732191206693521782":0.1611328125,"8001857008351451444":0.21484375},"applied_rules":["walk forward","walk back"]}]},"rules":["walk forward","walk back"],"possible_states":{"10921680398206464020":{"entities":{"main":{"parameters":{"point":0.0}}}},"7911799719936081424":{"entities":{"main":{"parameters":{"point":4.0}}}},"16318861240434570188":{"entities":{"main":{"parameters":{"point":2.0}}}},"3732191206693521782":{"entities":{"main":{"parameters":{"point":1.0}}}},"8001857008351451444":{"entities":{"main":{"parameters":{"point":3.0}}}}},"cache":{"rules":{"walk forward":{"condition":{"10921680398206464020":true,"7911799719936081424":true,"16318861240434570188":true,"3732191206693521782":true,"8001857008351451444":true},"actions":{"10921680398206464020":3732191206693521782,"7911799719936081424":10921680398206464020,"16318861240434570188":8001857008351451444,"3732191206693521782":16318861240434570188,"8001857008351451444":7911799719936081424}},"walk back":{"condition":{"10921680398206464020":true,"7911799719936081424":true,"16318861240434570188":true,"3732191206693521782":true,"8001857008351451444":true},"actions":{"10921680398206464020":7911799719936081424,"7911799719936081424":8001857008351451444,"16318861240434570188":3732191206693521782,"3732191206693521782":10921680398206464020,"8001857008351451444":16318861240434570188}}}}}"#
+    );
+    assert_eq!(
+        serde_json::from_value::<SerializableSimulation>(
+            serde_json::to_value(&serializable_simulation).unwrap()
+        )
+        .unwrap(),
+        serializable_simulation
+    );
+    let reconstructed_simulation: Simulation =
+        Simulation::from_serializable(serializable_simulation, simulation.rules().clone()).unwrap();
+    assert_eq!(reconstructed_simulation, simulation);
+}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box
-->
<!-- Derived from https://github.com/tauri-apps/tauri/blob/dev/.github/PULL_REQUEST_TEMPLATE.md -->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Code style update
- [ ] Refactor
- [ ] Performance
- [ ] Test
- [ ] CI
- [ ] Other, please describe:

### Description
<!-- Describe your changes in detail -->

This pull request adds serde support for most structs in entromatica. The only part which is currently not possible to serialize is the function in rules. This problem is solved by creating a `SerializableSimulation` (and `SerializableHistory` and `SerializableStep` respectively), which carry part of the information and are serializable. Most features, such as the cache, reachable states or possible states are being preserved. Only the rules are neglected, and only their names are stored. When converting a `SerializableSimulation` to an ordinary `Simulation`, the caller has to provide the set of rules in form of a HashMap.

### Reason for change
<!-- If this is a bug fix, provide the issue number. If this is a feature, explain why the change is necessary. If this is a documentation change, explain why it should be added. -->

Serialization is a critical when trying to store the simulation in a file. Although serializing rules is currently not possible, one can at least create backups.

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature
- [ ] I have added necessary documentation
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

### Other information